### PR TITLE
fix(deps): merge Dependabot security updates from dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8097,9 +8097,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "8.6.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.6.3.tgz",
-      "integrity": "sha512-alQyzT0j401LGBtwsqu6uprjR6pfNH1UJf9N6GBFMjIcd+HzTe0/HrjAbFCqun+zvnfLarrxAtMM2xvZ+kFZ5A==",
+      "version": "8.7.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.1.tgz",
+      "integrity": "sha512-agdGHrXNTv0IrYscJPDou/PlEJk1c/hBZ9o/B5NH2i/nSPtPqacNxzgwf1CebXxFMjMrZH5sqv9uQuw96aGt/A==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "long": "^5.3.2"
@@ -9805,9 +9805,9 @@
       "optional": true
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     },
     "node-forge": ">=1.4.0",
     "picomatch": ">=4.0.4",
-    "protobufjs": ">=7.5.8",
-    "uuid": ">=11.1.1"
+    "protobufjs": ">=8.6.6",
+    "uuid": ">=11.1.1",
+    "websocket-driver": ">=0.7.5"
   }
 }


### PR DESCRIPTION
## Summary
- Merges Dependabot security fixes from `dev` into `main`
- Bumps `protobufjs` to 8.7.1 and `websocket-driver` to 0.7.5 via npm overrides and lockfile

## Test plan
- [ ] CI / Vercel checks pass
- [ ] Dependabot alert count drops after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency requirements for improved compatibility and security.
  * Added minimum version coverage for the WebSocket driver package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->